### PR TITLE
Added new optional entitlements-path argument to support entitlements…

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This action only runs on macOS.
 
 | Name | Description | Example Value                         | Required |
 | ---- | ----------- |---------------------------------------| -------- |
-| certificate | The certificate for signing | `${{ secrets.CERTIFICATE }}`          | Yes |
+| certificate | The certificate for signing | `${{ secrets.CERTIFICATE }}` | Yes |
 | certificate-password | The password for the certificate | `${{ secrets.CERTIFICATE_PASSWORD }}` | Yes |
-| username | The Apple ID username to use for notarization | `${{ secrets.APPLE_ID_USERNAME }}`    | Yes |
-| password | The Apple ID password to use for notarization | `${{ secrets.APPLE_ID_PASSWORD }}`    | Yes |
-| apple-team-id | The Apple Team ID to use for signing and notarization | `33DS2ZRDST`                          | Yes |
-| app-path | The path to the application to sign and notarize | `build/my_app`                        | Yes |
-| entitlements-path | The path to the entitlements file to use for signing | `src/entitlements.plist`              | No |
+| username | The Apple ID username to use for notarization | `${{ secrets.APPLE_ID_USERNAME }}` | Yes |
+| password | The Apple ID password to use for notarization | `${{ secrets.APPLE_ID_PASSWORD }}` | Yes |
+| apple-team-id | The Apple Team ID to use for signing and notarization | `33DS2ZRDST` | Yes |
+| app-path | The path to the application to sign and notarize | `build/my_app` | Yes |
+| entitlements-path | The path to the entitlements file to use for signing | `src/entitlements.plist` | No |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,22 +6,21 @@ This action only runs on macOS.
 
 ## Inputs
 
-All inputs are required.
-
-| Name | Description | Example Value |
-| ---- | ----------- | ------------- |
-| certificate | The certificate for signing | `${{ secrets.CERTIFICATE }}` |
-| certificate-password | The password for the certificate | `${{ secrets.CERTIFICATE_PASSWORD }}` |
-| username | The Apple ID username to use for notarization | `${{ secrets.APPLE_ID_USERNAME }}` |
-| password | The Apple ID password to use for notarization | `${{ secrets.APPLE_ID_PASSWORD }}` |
-| apple-team-id | The Apple Team ID to use for signing and notarization | `33DS2ZRDST` |
-| app-path | The path to the application to sign and notarize | `build/my_app` |
+| Name | Description | Example Value                         | Required |
+| ---- | ----------- |---------------------------------------| -------- |
+| certificate | The certificate for signing | `${{ secrets.CERTIFICATE }}`          | Yes |
+| certificate-password | The password for the certificate | `${{ secrets.CERTIFICATE_PASSWORD }}` | Yes |
+| username | The Apple ID username to use for notarization | `${{ secrets.APPLE_ID_USERNAME }}`    | Yes |
+| password | The Apple ID password to use for notarization | `${{ secrets.APPLE_ID_PASSWORD }}`    | Yes |
+| apple-team-id | The Apple Team ID to use for signing and notarization | `33DS2ZRDST`                          | Yes |
+| app-path | The path to the application to sign and notarize | `build/my_app`                        | Yes |
+| entitlements-path | The path to the entitlements file to use for signing | `src/entitlements.plist`              | No |
 
 ## Usage
 
 ```yaml
 - name: Sign and notarize the release build
-  uses: toitlang/action-macos-sign-notarize@v1
+  uses: toitlang/action-macos-sign-notarize@v1.1.0
   with:
     certificate: ${{ secrets.CERTIFICATE }}
     certificate-password: ${{ secrets.CERTIFICATE_PASSWORD }}

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   app-path:
     description: "The path to the application to sign and notarize."
     required: true
+  entitlements-path:
+    description: "The path to the entitlements file to use for signing."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -51,6 +55,14 @@ runs:
           echo "Input password is missing."
           exit 1
         fi
+        if [[ -z "${{ inputs.apple-team-id }}" ]]; then
+          echo "Input apple-team-id is missing."
+          exit 1
+        fi
+        if [[ -z "${{ inputs.app-path }}" ]]; then
+          echo "Input app-path is missing."
+          exit 1
+        fi
 
     - name: Install dependencies
       shell: bash
@@ -67,8 +79,12 @@ runs:
     - name: Code sign
       shell: bash
       run: |
+        entitlements_arg=""
+        if [[ ! -z "${{ inputs.entitlements-path }}" ]]; then
+            entitlements_arg="--entitlements \"${{ inputs.entitlements-path }}\""
+        fi
         security find-identity -v signing_temp.keychain | grep "${{ inputs.apple-team-id }}" | grep "Developer ID Application"
-        codesign --keychain signing_temp.keychain --force --deep --sign "${{ inputs.apple-team-id }}" "${{ inputs.app-path }}" --options=runtime
+        codesign --keychain signing_temp.keychain --force --deep --sign "${{ inputs.apple-team-id }}" ${entitlements_arg} "${{ inputs.app-path }}" --options=runtime
 
     - name: Create a tmp directory
       id: tmp


### PR DESCRIPTION
Hello,

I added new optional entitlements-path argument to support entitlements during codesigning.  Updated README.md to reflect new arg.  Added missing input validations.

Also - when I had used: `uses: toitlang/action-macos-sign-notarize@v1` in my pipeline - I got an error.  I had to use: `uses: toitlang/action-macos-sign-notarize@v1.0.0`.  I've updated the readme to reflect version `1.1.0` - assuming you accept this PR and use that release version.

Thank you for this wonderful tool!
